### PR TITLE
Improve performance of DICOMfileClient

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 --exclude='bin,build,.eggs'
+    - name: Check type hints with mypy
+      run: |
+        mypy src
     - name: Test with pytest
       run: |
         pytest --cov=dicomweb_client --cov-fail-under=65 tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,7 @@
-mypy==0.910
+mypy==0.941
 pytest==6.2.4
 pytest-cov==2.12.1
 pytest-flake8==1.0.7
 pytest-localserver==0.5.0
+types-requests==2.27.14
+types-Pillow==9.0.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ statistics = True
 [mypy]
 warn_unreachable = True
 
-[mypy-google.auth.*]
+[mypy-google.*]
 ignore_missing_imports = True
 
 [mypy-pydicom.*]

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setuptools.setup(
     version=version,
     description='Client for DICOMweb RESTful services.',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Markus D. Herrmann',
     maintainer='Markus D. Herrmann',
     url='https://github.com/herrmannlab/dicomweb-client',

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -1061,10 +1061,11 @@ class DICOMfileClient:
         Optional[str],
         Optional[str],
     ]:
-        return tuple([
+        metadata = [
             self._get_data_element_value(dataset, attr)
             for attr in self._attributes[_QueryResourceType.STUDIES]
-        ])  # type: ignore
+        ]
+        return tuple(metadata)  # type: ignore
 
     def _extract_series_metadata(
         self,
@@ -1076,10 +1077,11 @@ class DICOMfileClient:
         Optional[str],
         Optional[int],
     ]:
-        return tuple([
+        metadata = [
             self._get_data_element_value(dataset, attr)
             for attr in self._attributes[_QueryResourceType.SERIES]
-        ])  # type: ignore
+        ]
+        return tuple(metadata)  # type: ignore
 
     def _extract_instance_metadata(
         self,

--- a/src/dicomweb_client/file.py
+++ b/src/dicomweb_client/file.py
@@ -829,7 +829,7 @@ class DICOMfileClient:
         # such as PyTorch or TensorFlow.
         try:
             if self._db_cursor_handle is not None:
-                self._db_curor_handle.execute('PRAGMA optimize')
+                self._db_cursor_handle.execute('PRAGMA optimize')
                 self._db_cursor_handle.close()
             if self._db_connection_handle is not None:
                 self._db_connection_handle.commit()

--- a/src/dicomweb_client/protocol.py
+++ b/src/dicomweb_client/protocol.py
@@ -12,7 +12,7 @@ from typing import (
 if sys.version_info.minor < 8:
     from typing_extensions import Protocol, runtime_checkable
 else:
-    from typing import Protocol, runtime_checkable
+    from typing import Protocol, runtime_checkable  # type: ignore
 
 from pydicom.dataset import Dataset
 
@@ -64,13 +64,13 @@ class DICOMClient(Protocol):
         Remaining results can be requested via repeated calls using the
         `offset` parameter.
 
-        """  # noqa: E501: E501
+        """  # noqa: E501
         pass
 
     def retrieve_bulkdata(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None
     ) -> List[bytes]:
         """Retrieve bulk data at a given location.
@@ -79,7 +79,7 @@ class DICOMClient(Protocol):
         ----------
         url: str
             Location of the bulk data
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -90,13 +90,13 @@ class DICOMClient(Protocol):
         List[bytes]
             Bulk data items
 
-        """
+        """  # noqa: E501
         pass
 
     def iter_bulkdata(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None
     ) -> Iterator[bytes]:
         """Iterate over bulk data items at a given location.
@@ -105,7 +105,7 @@ class DICOMClient(Protocol):
         ----------
         url: str
             Location of the bulk data
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -116,13 +116,13 @@ class DICOMClient(Protocol):
         Iterator[bytes]
             Bulk data items
 
-        """
+        """  # noqa: E501
         pass
 
     def retrieve_study(
         self,
         study_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
     ) -> List[Dataset]:
         """Retrieve all instances of a study.
 
@@ -130,7 +130,7 @@ class DICOMClient(Protocol):
         ----------
         study_instance_uid: str
             Study Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -149,13 +149,13 @@ class DICOMClient(Protocol):
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         pass
 
     def iter_study(
         self,
         study_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
     ) -> Iterator[Dataset]:
         """Iterate over all instances of a study.
 
@@ -163,7 +163,7 @@ class DICOMClient(Protocol):
         ----------
         study_instance_uid: str
             Study Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -182,7 +182,7 @@ class DICOMClient(Protocol):
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         pass
 
     def retrieve_study_metadata(
@@ -277,7 +277,7 @@ class DICOMClient(Protocol):
         self,
         study_instance_uid: str,
         series_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> List[Dataset]:
         """Retrieve all instances of a series.
 
@@ -287,7 +287,7 @@ class DICOMClient(Protocol):
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -306,14 +306,14 @@ class DICOMClient(Protocol):
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         pass
 
     def iter_series(
         self,
         study_instance_uid: str,
         series_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> Iterator[Dataset]:
         """Iterate over all instances of a series.
 
@@ -323,7 +323,7 @@ class DICOMClient(Protocol):
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -342,7 +342,7 @@ class DICOMClient(Protocol):
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         pass
 
     def retrieve_series_metadata(
@@ -370,7 +370,7 @@ class DICOMClient(Protocol):
     def retrieve_series_rendered(
         self, study_instance_uid,
         series_instance_uid,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None
     ) -> bytes:
         """Retrieve rendered representation of a series.
@@ -381,7 +381,7 @@ class DICOMClient(Protocol):
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types (choices: ``"image/jpeg"``, ``"image/jp2"``,
             ``"image/gif"``, ``"image/png"``, ``"video/gif"``, ``"video/mp4"``,
             ``"video/h265"``, ``"text/html"``, ``"text/plain"``,
@@ -395,7 +395,7 @@ class DICOMClient(Protocol):
         bytes
             Rendered representation of series
 
-        """
+        """  # noqa: E501
         pass
 
     def delete_series(
@@ -481,7 +481,7 @@ class DICOMClient(Protocol):
         study_instance_uid: str,
         series_instance_uid: str,
         sop_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
     ) -> Dataset:
         """Retrieve an individual instance.
 
@@ -493,7 +493,7 @@ class DICOMClient(Protocol):
             Series Instance UID
         sop_instance_uid: str
             SOP Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -512,7 +512,7 @@ class DICOMClient(Protocol):
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         pass
 
     def store_instances(
@@ -597,7 +597,7 @@ class DICOMClient(Protocol):
         study_instance_uid: str,
         series_instance_uid: str,
         sop_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None
     ) -> bytes:
         """Retrieve an individual, server-side rendered instance.
@@ -610,7 +610,7 @@ class DICOMClient(Protocol):
             Series Instance UID
         sop_instance_uid: str
             SOP Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types (choices: ``"image/jpeg"``, ``"image/jp2"``,
             ``"image/gif"``, ``"image/png"``, ``"video/gif"``, ``"video/mp4"``,
             ``"video/h265"``, ``"text/html"``, ``"text/plain"``,
@@ -624,7 +624,7 @@ class DICOMClient(Protocol):
         bytes
             Rendered representation of instance
 
-        """
+        """  # noqa: E501
         pass
 
     def retrieve_instance_frames(
@@ -633,7 +633,7 @@ class DICOMClient(Protocol):
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> List[bytes]:
         """Retrieve one or more frames of an image instance.
 
@@ -647,7 +647,7 @@ class DICOMClient(Protocol):
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional indices of the frames within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
 
@@ -656,7 +656,7 @@ class DICOMClient(Protocol):
         List[bytes]
             Pixel data for each frame
 
-        """
+        """  # noqa: E501
         pass
 
     def iter_instance_frames(
@@ -665,7 +665,7 @@ class DICOMClient(Protocol):
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> Iterator[bytes]:
         """Iterate over frames of an image instance.
 
@@ -679,7 +679,7 @@ class DICOMClient(Protocol):
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional indices of the frames within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
 
@@ -688,7 +688,7 @@ class DICOMClient(Protocol):
         Iterator[bytes]
             Pixel data for each frame
 
-        """
+        """  # noqa: E501
         pass
 
     def retrieve_instance_frames_rendered(
@@ -697,7 +697,7 @@ class DICOMClient(Protocol):
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None
     ) -> bytes:
         """Retrieve one or more server-side rendered frames of an instance.
@@ -712,7 +712,7 @@ class DICOMClient(Protocol):
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional index of the frame within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media type (choices: ``"image/jpeg"``, ``"image/jp2"``,
             ``"image/gif"``, ``"image/png"``)
         params: Union[Dict[str, Any], None], optional
@@ -728,5 +728,5 @@ class DICOMClient(Protocol):
         ----
         Not all media types are compatible with all SOP classes.
 
-        """
+        """  # noqa: E501
         pass

--- a/src/dicomweb_client/web.py
+++ b/src/dicomweb_client/web.py
@@ -673,6 +673,8 @@ class DICOMwebClient:
 
         if get_remaining:
             results = []
+            if params is None:
+                params = {}
             params['offset'] = params.get('offset', 0)
             while True:
                 subset = get(url, params, stream)
@@ -895,7 +897,7 @@ class DICOMwebClient:
     @classmethod
     def _build_accept_header_field_value(
         cls,
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None],
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None],
         supported_media_types: Set[str]
     ) -> str:
         """Build an accept header field value for a request message.
@@ -936,14 +938,14 @@ class DICOMwebClient:
     @classmethod
     def _build_multipart_accept_header_field_value(
         cls,
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None],
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None],
         supported_media_types: Union[Dict[str, str], Set[str]]
     ) -> str:
         """Build an accept header field value for a multipart request message.
 
         Parameters
         ----------
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None]
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None]
             Acceptable media types and optionally the UIDs of the corresponding
             transfer syntaxes
         supported_media_types: Union[Dict[str, str], Set[str]]
@@ -1018,7 +1020,7 @@ class DICOMwebClient:
     def _http_get_multipart_application_dicom(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
     ) -> Iterator[pydicom.dataset.Dataset]:
@@ -1028,7 +1030,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes, (defaults to
             ``("application/dicom", "1.2.840.10008.1.2.1")``)
@@ -1043,7 +1045,7 @@ class DICOMwebClient:
         Iterator[pydicom.dataset.Dataset]
             DICOM data sets
 
-        """
+        """  # noqa: E501
         default_media_type = 'application/dicom'
         supported_media_types = {
             '1.2.840.10008.1.2.1': default_media_type,
@@ -1106,7 +1108,7 @@ class DICOMwebClient:
     def _http_get_multipart(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
@@ -1117,7 +1119,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes (defaults to ``("*/*", )``)
         byte_range: Union[Tuple[int, int], None], optional
@@ -1133,7 +1135,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Content of HTTP message body parts
 
-        """
+        """  # noqa: E501
         default_media_type = '*/*'
         supported_media_types = {
             '1.2.840.10008.1.2.1': 'application/octet-stream',
@@ -1177,7 +1179,7 @@ class DICOMwebClient:
     def _http_get_multipart_application_octet_stream(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
@@ -1188,7 +1190,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes (defaults to
             ``("application/octet-stream", "1.2.840.10008.1.2.1")``)
@@ -1205,7 +1207,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Content of HTTP message body parts
 
-        """
+        """  # noqa: E501
         default_media_type = 'application/octet-stream'
         supported_media_types = {
             '1.2.840.10008.1.2.1': default_media_type,
@@ -1231,7 +1233,7 @@ class DICOMwebClient:
     def _http_get_multipart_image(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
@@ -1242,7 +1244,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -1258,7 +1260,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Content of HTTP message body parts
 
-        """
+        """  # noqa: E501
         headers = {}
         supported_media_types = {
             '1.2.840.10008.1.2.5': 'image/x-dicom-rle',
@@ -1292,7 +1294,7 @@ class DICOMwebClient:
     def _http_get_multipart_video(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
@@ -1303,7 +1305,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Tuple[Union[str, Tuple[str, str]]]
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -1319,7 +1321,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Content of HTTP message body parts
 
-        """
+        """  # noqa: E501
         headers = {}
         supported_media_types = {
             '1.2.840.10008.1.2.4.100': 'video/mpeg2',
@@ -1383,7 +1385,7 @@ class DICOMwebClient:
     def _http_get_image(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
     ) -> bytes:
@@ -1393,7 +1395,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Image media type (choices: ``"image/jpeg"``, ``"image/gif"``,
             ``"image/jp2"``, ``"image/png"``)
         params: Union[Dict[str, Any], None], optional
@@ -1407,7 +1409,7 @@ class DICOMwebClient:
         bytes
             Content of HTTP message body
 
-        """
+        """  # noqa: E501
         supported_media_types = {
             'image/',
             'image/*',
@@ -1431,7 +1433,7 @@ class DICOMwebClient:
     def _http_get_video(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
     ) -> bytes:
@@ -1441,7 +1443,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Video media type (choices: ``"video/mpeg"``, ``"video/mp4"``,
             ``"video/H265"``)
         params: Union[Dict[str, Any], None], optional
@@ -1455,7 +1457,7 @@ class DICOMwebClient:
         bytes
             Content of HTTP message body
 
-        """
+        """  # noqa: E501
         supported_media_types = {
             'video/',
             'video/*',
@@ -1478,7 +1480,7 @@ class DICOMwebClient:
     def _http_get_text(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None,
         stream: bool = False
     ) -> bytes:
@@ -1488,7 +1490,7 @@ class DICOMwebClient:
         ----------
         url: str
             Unique resource locator
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Text media type (choices: ``"text/html"``, ``"text/plain"``,
             ``"text/xml"``, ``"text/rtf"``)
         params: Union[Dict[str, Any], None], optional
@@ -1502,7 +1504,7 @@ class DICOMwebClient:
         bytes
             Content of HTTP message body
 
-        """
+        """  # noqa: E501
         supported_media_types = {
             'text/',
             'text/*',
@@ -1754,7 +1756,7 @@ class DICOMwebClient:
     @classmethod
     def _get_common_media_types(
         cls,
-        media_types: Tuple[Union[str, Tuple[str, str]]]
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> List[str]:
         """Get media types of one resource category.
 
@@ -1771,7 +1773,7 @@ class DICOMwebClient:
 
         Parameters
         ----------
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
 
@@ -1785,7 +1787,7 @@ class DICOMwebClient:
         ValueError
             when no media types are provided or more than one type is provided
 
-        """
+        """  # noqa: E501
         if media_types is None:
             raise ValueError('No acceptable media types provided.')
         common_media_types = []
@@ -1819,7 +1821,7 @@ class DICOMwebClient:
     def _get_bulkdata(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None,
         stream: bool = False,
     ) -> Iterator[bytes]:
@@ -1829,7 +1831,7 @@ class DICOMwebClient:
         ----------
         url: str
             Location of the bulk data
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -1843,7 +1845,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Bulk data items
 
-        """
+        """  # noqa: E501
         if media_types is None:
             return self._http_get_multipart(
                 url, media_types, byte_range=byte_range, stream=stream
@@ -1876,7 +1878,7 @@ class DICOMwebClient:
     def retrieve_bulkdata(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None
     ) -> List[bytes]:
         """Retrieve bulk data at a given location.
@@ -1885,7 +1887,7 @@ class DICOMwebClient:
         ----------
         url: str
             Location of the bulk data
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -1896,7 +1898,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Bulk data items
 
-        """
+        """  # noqa: E501
         return list(
             self._get_bulkdata(
                 url=url,
@@ -1909,7 +1911,7 @@ class DICOMwebClient:
     def iter_bulkdata(
         self,
         url: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         byte_range: Optional[Tuple[int, int]] = None
     ) -> Iterator[bytes]:
         """Iterate over bulk data items at a given location.
@@ -1918,7 +1920,7 @@ class DICOMwebClient:
         ----------
         url: str
             Location of the bulk data
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         byte_range: Union[Tuple[int, int], None], optional
@@ -1933,7 +1935,7 @@ class DICOMwebClient:
         ----
         Data is streamed from the DICOMweb server.
 
-        """
+        """  # noqa: E501
         return self._get_bulkdata(
             url=url,
             media_types=media_types,
@@ -1944,7 +1946,7 @@ class DICOMwebClient:
     def _get_study(
         self,
         study_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         stream: bool = False
     ) -> Iterator[pydicom.dataset.Dataset]:
         """Get all instances of a study.
@@ -1953,7 +1955,7 @@ class DICOMwebClient:
         ----------
         study_instance_uid: str
             Study Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxescceptable transfer syntax UIDs
         stream: bool, optional
@@ -1965,7 +1967,7 @@ class DICOMwebClient:
         Iterator[pydicom.dataset.Dataset]
             Instances
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of study.'
@@ -1997,7 +1999,7 @@ class DICOMwebClient:
     def retrieve_study(
         self,
         study_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
     ) -> List[pydicom.dataset.Dataset]:
         """Retrieve all instances of a study.
 
@@ -2005,7 +2007,7 @@ class DICOMwebClient:
         ----------
         study_instance_uid: str
             Study Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -2024,7 +2026,7 @@ class DICOMwebClient:
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         return list(
             self._get_study(
                 study_instance_uid=study_instance_uid,
@@ -2036,7 +2038,7 @@ class DICOMwebClient:
     def iter_study(
         self,
         study_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
     ) -> Iterator[pydicom.dataset.Dataset]:
         """Iterate over all instances of a study.
 
@@ -2044,7 +2046,7 @@ class DICOMwebClient:
         ----------
         study_instance_uid: str
             Study Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -2067,7 +2069,7 @@ class DICOMwebClient:
         ----
         Data is streamed from the DICOMweb server.
 
-        """
+        """  # noqa: E501
         return self._get_study(
             study_instance_uid=study_instance_uid,
             media_types=media_types,
@@ -2213,7 +2215,7 @@ class DICOMwebClient:
         self,
         study_instance_uid: str,
         series_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         stream: bool = False
     ) -> Iterator[pydicom.dataset.Dataset]:
         """Get instances of a series.
@@ -2224,7 +2226,7 @@ class DICOMwebClient:
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         stream: bool, optional
@@ -2236,7 +2238,7 @@ class DICOMwebClient:
         Iterator[pydicom.dataset.Dataset]
             Instances
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of series.'
@@ -2283,7 +2285,7 @@ class DICOMwebClient:
         self,
         study_instance_uid: str,
         series_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> List[pydicom.dataset.Dataset]:
         """Retrieve all instances of a series.
 
@@ -2293,7 +2295,7 @@ class DICOMwebClient:
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -2312,7 +2314,7 @@ class DICOMwebClient:
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         return list(
             self._get_series(
                 study_instance_uid=study_instance_uid,
@@ -2326,7 +2328,7 @@ class DICOMwebClient:
         self,
         study_instance_uid: str,
         series_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> Iterator[pydicom.dataset.Dataset]:
         """Iterate over all instances of a series.
 
@@ -2336,7 +2338,7 @@ class DICOMwebClient:
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -2359,7 +2361,7 @@ class DICOMwebClient:
         ----
         Data is streamed from the DICOMweb server.
 
-        """
+        """  # noqa: E501
         return self._get_series(
             study_instance_uid=study_instance_uid,
             series_instance_uid=series_instance_uid,
@@ -2414,7 +2416,7 @@ class DICOMwebClient:
     def retrieve_series_rendered(
         self, study_instance_uid,
         series_instance_uid,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None
     ) -> bytes:
         """Retrieve rendered representation of a series.
@@ -2425,7 +2427,7 @@ class DICOMwebClient:
             Study Instance UID
         series_instance_uid: str
             Series Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types (choices: ``"image/jpeg"``, ``"image/jp2"``,
             ``"image/gif"``, ``"image/png"``, ``"video/gif"``, ``"video/mp4"``,
             ``"video/h265"``, ``"text/html"``, ``"text/plain"``,
@@ -2439,7 +2441,7 @@ class DICOMwebClient:
         bytes
             Rendered representation of series
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of '
@@ -2467,7 +2469,8 @@ class DICOMwebClient:
         common_media_types = self._get_common_media_types(media_types)
         if len(common_media_types) > 1:
             # Try and hope for the best...
-            return self._http_get(url, params)
+            response = self._http_get(url, params)
+            return response.content
 
         common_media_type = common_media_types[0]
         if common_media_type.startswith('image'):
@@ -2602,7 +2605,7 @@ class DICOMwebClient:
         study_instance_uid: str,
         series_instance_uid: str,
         sop_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
     ) -> pydicom.dataset.Dataset:
         """Retrieve an individual instance.
 
@@ -2614,7 +2617,7 @@ class DICOMwebClient:
             Series Instance UID
         sop_instance_uid: str
             SOP Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             acceptable transfer syntaxes
 
@@ -2633,7 +2636,7 @@ class DICOMwebClient:
         acceptable transfer syntaxes using the wildcard
         ``("application/dicom", "*")``.
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of instance.'
@@ -2817,7 +2820,7 @@ class DICOMwebClient:
         study_instance_uid: str,
         series_instance_uid: str,
         sop_instance_uid: str,
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None
     ) -> bytes:
         """Retrieve an individual, server-side rendered instance.
@@ -2830,7 +2833,7 @@ class DICOMwebClient:
             Series Instance UID
         sop_instance_uid: str
             SOP Instance UID
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types (choices: ``"image/jpeg"``, ``"image/jp2"``,
             ``"image/gif"``, ``"image/png"``, ``"video/gif"``, ``"video/mp4"``,
             ``"video/h265"``, ``"text/html"``, ``"text/plain"``,
@@ -2844,7 +2847,7 @@ class DICOMwebClient:
         bytes
             Rendered representation of instance
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of '
@@ -2899,7 +2902,7 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         stream: bool = False
     ) -> Iterator[bytes]:
         """Get frames of an instance.
@@ -2914,7 +2917,7 @@ class DICOMwebClient:
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional indices of the frames within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
         stream: bool, optional
@@ -2926,7 +2929,7 @@ class DICOMwebClient:
         Iterator[bytes]
             Pixel data for each frame
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of frames.'
@@ -2995,7 +2998,7 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> List[bytes]:
         """Retrieve one or more frames of an image instance.
 
@@ -3009,7 +3012,7 @@ class DICOMwebClient:
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional indices of the frames within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
 
@@ -3018,7 +3021,7 @@ class DICOMwebClient:
         List[bytes]
             Pixel data for each frame
 
-        """
+        """  # noqa: E501
         return list(
             self._get_instance_frames(
                 study_instance_uid=study_instance_uid,
@@ -3036,7 +3039,7 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None
     ) -> Iterator[bytes]:
         """Iterate over frames of an image instance.
 
@@ -3050,7 +3053,7 @@ class DICOMwebClient:
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional indices of the frames within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media types and optionally the UIDs of the
             corresponding transfer syntaxes
 
@@ -3063,7 +3066,7 @@ class DICOMwebClient:
         ----
         Data is streamed from the DICOMweb server.
 
-        """
+        """  # noqa: E501
         return self._get_instance_frames(
             study_instance_uid=study_instance_uid,
             series_instance_uid=series_instance_uid,
@@ -3079,7 +3082,7 @@ class DICOMwebClient:
         series_instance_uid: str,
         sop_instance_uid: str,
         frame_numbers: Sequence[int],
-        media_types: Optional[Tuple[Union[str, Tuple[str, str]]]] = None,
+        media_types: Optional[Tuple[Union[str, Tuple[str, str]], ...]] = None,
         params: Optional[Dict[str, Any]] = None
     ) -> bytes:
         """Retrieve one or more server-side rendered frames of an instance.
@@ -3094,7 +3097,7 @@ class DICOMwebClient:
             SOP Instance UID
         frame_numbers: Sequence[int]
             One-based positional index of the frame within the instance
-        media_types: Union[Tuple[Union[str, Tuple[str, str]]], None], optional
+        media_types: Union[Tuple[Union[str, Tuple[str, str]], ...], None], optional
             Acceptable media type (choices: ``"image/jpeg"``, ``"image/jp2"``,
             ``"image/gif"``, ``"image/png"``)
         params: Union[Dict[str, Any], None], optional
@@ -3110,7 +3113,7 @@ class DICOMwebClient:
         ----
         Not all media types are compatible with all SOP classes.
 
-        """
+        """  # noqa: E501
         if study_instance_uid is None:
             raise ValueError(
                 'Study Instance UID is required for retrieval of '
@@ -3158,7 +3161,7 @@ class DICOMwebClient:
 
     @staticmethod
     def lookup_keyword(
-        tag: Union[str, int, Tuple[str, str], pydicom.tag.BaseTag]
+        tag: Union[str, int, Tuple[int, int], pydicom.tag.BaseTag]
     ) -> str:
         """Look up the keyword of a DICOM attribute.
 
@@ -3173,7 +3176,10 @@ class DICOMwebClient:
             Attribute keyword (e.g. ``"SOPInstanceUID"``)
 
         """
-        return pydicom.datadict.keyword_for_tag(tag)
+        keyword = pydicom.datadict.keyword_for_tag(tag)
+        if keyword is None:
+            raise KeyError(f'Could not find a keyword for tag {tag}.')
+        return keyword
 
     @staticmethod
     def lookup_tag(keyword: str) -> str:
@@ -3191,5 +3197,7 @@ class DICOMwebClient:
 
         """
         tag = pydicom.datadict.tag_for_keyword(keyword)
+        if tag is None:
+            raise KeyError(f'Could not find a tag for "{keyword}".')
         tag = pydicom.tag.Tag(tag)
         return '{0:04x}{1:04x}'.format(tag.group, tag.element).upper()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,4 +30,4 @@ def client(httpserver):
 def file_client():
     '''Instance of `dicomweb_client.api.DICOMwebClient`.'''
     base_dir = Path(DATA_ROOT)
-    return DICOMfileClient(base_dir, recreate_db=True)
+    return DICOMfileClient(base_dir, recreate_db=True, in_memory=True)


### PR DESCRIPTION
This PR introduces several changes with the aim to improve read/write performance of the database underlying the `DICOMfileClient`:

1. Reuse database cursor object for all read operations to avoid overhead of creating/destroying cursor objects
2. Configure database to make less frequent OS write operations
3. Add support for in-memory database to avoid OS read/write operations altogether
