### PR TITLE
Read frames in parallel using multiple threads

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
         flake8 --exclude='bin,build,.eggs'
     - name: Check type hints with mypy
       run: |
-        mypy src
+        mypy src tests
     - name: Test with pytest
       run: |
         pytest --cov=dicomweb_client --cov-fail-under=65 tests


### PR DESCRIPTION
This PR introduces a change to the image file reader that is used by the `DICOMfileClient` to read individual frames from multi-frame images. So far, frames have been read sequentially. Now, we'll use a `multiprocessing.pool.ThreadPool` to read multiple frames in parallel. We use threads instead of processes, because the read operation is I/O bound rather than CPU bound and the GIL should thus not be a bottleneck.